### PR TITLE
feat: added parsing of comma separated string

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,12 +1,14 @@
 /**
- * Try safely to parse input to object. Return string if not possible.
+ * Try safely to parse input to object.
+ * Return string (w/o commas) if not possible.
  */
 export function parseInput(input: string) {
   try {
     const result = JSON.parse(input);
     return result;
   } catch (error) {
-    return input;
+    const result = input.replace(/,/g, ' ');
+    return result;
   }
 }
 

--- a/tests/details.test.ts
+++ b/tests/details.test.ts
@@ -64,6 +64,21 @@ describe('details', () => {
       });
   });
 
+  it('should parse comma separated parameters defined in projection', async () => {
+    const person = await PersonModel.create({name: faker.name.findName()});
+    await request
+      .get(`/persons/${person._id}`)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .query({
+        projection: 'name,-_id',
+      })
+      .then(({body}) => {
+        expect(body).toHaveProperty('name');
+        expect(body).not.toHaveProperty('_id');
+      });
+  });
+
   it('should return only properties defined in select', async () => {
     const person = await PersonModel.create({name: faker.name.findName()});
     await request
@@ -72,6 +87,21 @@ describe('details', () => {
       .expect('Content-Type', /json/)
       .query({
         select: 'name -_id',
+      })
+      .then(({body}) => {
+        expect(body).toHaveProperty('name');
+        expect(body).not.toHaveProperty('_id');
+      });
+  });
+
+  it('should parse comma separated parameters defined in select', async () => {
+    const person = await PersonModel.create({name: faker.name.findName()});
+    await request
+      .get(`/persons/${person._id}`)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .query({
+        select: 'name,-_id',
       })
       .then(({body}) => {
         expect(body).toHaveProperty('name');

--- a/tests/list.test.ts
+++ b/tests/list.test.ts
@@ -146,6 +146,23 @@ describe('list', () => {
       });
   });
 
+  it('should parse comma separated parameters defined in projection', async () => {
+    await PersonModel.create({name: faker.name.findName()});
+    await request
+      .get('/persons')
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .query({
+        projection: 'name,-_id',
+      })
+      .then(({body}) => {
+        expect(Array.isArray(body)).toEqual(true);
+        expect(body.length).toEqual(1);
+        expect(body[0]).toHaveProperty('name');
+        expect(body[0]).not.toHaveProperty('_id');
+      });
+  });
+
   it('should select what is returned in documents', async () => {
     await PersonModel.create({name: 'a', motto: faker.lorem.sentence()});
     await PersonModel.create({name: 'b', motto: faker.lorem.sentence()});
@@ -178,6 +195,43 @@ describe('list', () => {
         expect(body[1].motto).toBeTruthy();
         expect(body[2].name).toBeUndefined();
         expect(body[2].motto).toBeTruthy();
+      });
+  });
+
+  it('should parse comma separated parameters defined in select', async () => {
+    await PersonModel.create({
+      name: 'a',
+      motto: faker.lorem.sentence(),
+      address: {
+        street: 'Keskuojankatu',
+        city: 'Tampere',
+      },
+    });
+    await PersonModel.create({
+      name: 'b',
+      motto: faker.lorem.sentence(),
+      address: {
+        street: 'Mannerheimintie',
+        city: 'Helsinki',
+      },
+    });
+
+    await request
+      .get('/persons')
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .query({select: 'name,motto,address.street'})
+      .then(({body}) => {
+        expect(Array.isArray(body)).toEqual(true);
+        expect(body.length).toEqual(2);
+        expect(body[0].name).toEqual('a');
+        expect(body[0].motto).toBeTruthy();
+        expect(body[0].address.street).toEqual('Keskuojankatu');
+        expect(body[0].address.city).toBeUndefined();
+        expect(body[1].name).toEqual('b');
+        expect(body[1].motto).toBeTruthy();
+        expect(body[1].address.street).toEqual('Mannerheimintie');
+        expect(body[1].address.city).toBeUndefined();
       });
   });
 


### PR DESCRIPTION
If input string is not object for select, projection, populate or sort,
it is parsed out of commas