### PR TITLE
fix: x-total-count missing when count is zero

### DIFF
--- a/src/operations/list.ts
+++ b/src/operations/list.ts
@@ -94,7 +94,7 @@ export function List<T>(
     handler: async (request, reply) => {
       const {resources, totalCount} = await findOperation(model, request.query);
 
-      if (totalCount) {
+      if (totalCount !== undefined) {
         reply.header('X-Total-Count', totalCount);
       }
 

--- a/src/operations/search.ts
+++ b/src/operations/search.ts
@@ -103,7 +103,7 @@ export function Search<T>(
     handler: async (request, reply) => {
       const {resources, totalCount} = await findOperation(model, request.body);
 
-      if (totalCount) {
+      if (totalCount !== undefined) {
         reply.header('X-Total-Count', totalCount);
       }
 

--- a/tests/list.test.ts
+++ b/tests/list.test.ts
@@ -60,11 +60,11 @@ describe('list', () => {
       /**
        * Expected first document name
        */
-      first: string;
+      first?: string;
       /**
        * Expected last document name
        */
-      last: string;
+      last?: string;
       /**
        * Expected properties in returned documents
        */
@@ -240,6 +240,16 @@ describe('list', () => {
       },
     ],
     [
+      'should return header X-Total-Count with total count of documents with query that does not match any documents',
+      {query: JSON.stringify({name: 'z'}), totalCount: true},
+      {
+        length: 0,
+        headers: {
+          'x-total-count': '0',
+        },
+      },
+    ],
+    [
       'should not return header X-Total-Count if totalCount parameter is not present',
       {},
       {
@@ -387,8 +397,11 @@ describe('list', () => {
 
       expect(Array.isArray(body)).toEqual(true);
       expect(body.length).toEqual(length);
-      expect(body.at(0).name).toEqual(first);
-      expect(body.at(-1).name).toEqual(last);
+
+      if (length > 0) {
+        expect(body.at(0).name).toEqual(first);
+        expect(body.at(-1).name).toEqual(last);
+      }
 
       if (property) {
         Object.entries(property).forEach(([key, value]) => {

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -60,11 +60,11 @@ describe('search', () => {
       /**
        * Expected first document name
        */
-      first: string;
+      first?: string;
       /**
        * Expected last document name
        */
-      last: string;
+      last?: string;
       /**
        * Expected properties in returned documents
        */
@@ -292,6 +292,16 @@ describe('search', () => {
       },
     ],
     [
+      'should return header X-Total-Count with total count of documents with query that does not match any documents',
+      {query: {name: 'z'}, totalCount: true},
+      {
+        length: 0,
+        headers: {
+          'x-total-count': '0',
+        },
+      },
+    ],
+    [
       'should not return header X-Total-Count if totalCount parameter is not present',
       {},
       {
@@ -469,8 +479,11 @@ describe('search', () => {
 
       expect(Array.isArray(body)).toEqual(true);
       expect(body.length).toEqual(length);
-      expect(body.at(0).name).toEqual(first);
-      expect(body.at(-1).name).toEqual(last);
+
+      if (length > 0) {
+        expect(body.at(0).name).toEqual(first);
+        expect(body.at(-1).name).toEqual(last);
+      }
 
       if (property) {
         Object.entries(property).forEach(([key, value]) => {


### PR DESCRIPTION
- Modified `totalCount` condition to check for undefined explicitly instead of implicitly.
- Added tests to ensure feature works in the future